### PR TITLE
Fix missing road intersections in map loader

### DIFF
--- a/src/map_loader.erl
+++ b/src/map_loader.erl
@@ -75,7 +75,9 @@ create_all_locations(JsonRoads, NamedLocations) ->
         sets:add_element({round(maps:get(<<"x2">>, Road)), round(maps:get(<<"y2">>, Road))}, Acc))
     end, sets:new(), JsonRoads),
 
-    JunctionCoords = sets:subtract(AllRoadEndpoints, NamedCoords),
+    IntersectionCoords = find_intersections(JsonRoads),
+    AllJunctions = sets:union(AllRoadEndpoints, IntersectionCoords),
+    JunctionCoords = sets:subtract(AllJunctions, NamedCoords),
     {Junctions, _} = lists:mapfoldl(
         fun({X, Y}, Index) ->
             Id = "junction_" ++ integer_to_list(Index),
@@ -153,6 +155,42 @@ remove_duplicate_roads(Roads) ->
         maps:put(Key, Road, Map)
     end, #{}, Roads),
     maps:values(RoadMap).
+
+%% @doc מחשב את כל נקודות החיתוך בין קטעי כביש ומחזיר אותן כ-Set.
+find_intersections(JsonRoads) ->
+    Roads = [ {round(maps:get(<<"x1">>, R)), round(maps:get(<<"y1">>, R)),
+               round(maps:get(<<"x2">>, R)), round(maps:get(<<"y2">>, R))}
+             || R <- JsonRoads ],
+    find_intersections(Roads, [], sets:new()).
+
+find_intersections([R | Rest], Processed, Acc) ->
+    NewAcc = lists:foldl(fun(R2, A) ->
+        case line_intersection(R, R2) of
+            none -> A;
+            {X, Y} -> sets:add_element({X, Y}, A)
+        end
+    end, Acc, Processed),
+    find_intersections(Rest, [R | Processed], NewAcc);
+find_intersections([], _Processed, Acc) ->
+    Acc.
+
+%% @doc בודק האם שני קטעים נחתכים ומחזיר את נקודת החיתוך העגולה.
+line_intersection({X1,Y1,X2,Y2}, {X3,Y3,X4,Y4}) ->
+    Den = (X1 - X2)*(Y3 - Y4) - (Y1 - Y2)*(X3 - X4),
+    case Den of
+        0 -> none; % מקבילים
+        _ ->
+            Px = ((X1*Y2 - Y1*X2)*(X3 - X4) - (X1 - X2)*(X3*Y4 - Y3*X4)) / Den,
+            Py = ((X1*Y2 - Y1*X2)*(Y3 - Y4) - (Y1 - Y2)*(X3*Y4 - Y3*X4)) / Den,
+            if
+                Px >= min(X1,X2) andalso Px =< max(X1,X2) andalso
+                Px >= min(X3,X4) andalso Px =< max(X3,X4) andalso
+                Py >= min(Y1,Y2) andalso Py =< max(Y1,Y2) andalso
+                Py >= min(Y3,Y4) andalso Py =< max(Y3,Y4) ->
+                    {round(Px), round(Py)};
+                true -> none
+            end
+    end.
 
 %% -----------------------------------------------------------
 %% שמירה ב-ETS ובניית הגרף


### PR DESCRIPTION
## Summary
- detect road intersection points when loading the static map
- create junction nodes at these intersections
- add helper functions to calculate intersections

## Testing
- `rebar3 compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef75317a083319c0414a6cfa36bff