### PR TITLE
Implement node monitoring and global registration

### DIFF
--- a/src/control_center.erl
+++ b/src/control_center.erl
@@ -21,7 +21,7 @@
 %% -----------------------------------------------------------
 
 start_link() ->
-    gen_statem:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_statem:start_link({via, global, ?MODULE}, ?MODULE, [], []).
 
 callback_mode() ->
     state_functions.

--- a/src/courier.erl
+++ b/src/courier.erl
@@ -26,7 +26,8 @@
 %% יצירת שליח חדש (כולל שם דינמי לפי מזהה)
 %% -----------------------------------------------------------
 start_link(CourierId) ->
-    gen_statem:start_link({local, list_to_atom("courier_" ++ CourierId)}, ?MODULE, [CourierId], []).
+    Name = list_to_atom("courier_" ++ CourierId),
+    gen_statem:start_link({via, global, Name}, ?MODULE, [CourierId], []).
 
 % הוספת פונקציות API להשהיה והמשך
 pause(CourierId) ->

--- a/src/courier_pool.erl
+++ b/src/courier_pool.erl
@@ -20,7 +20,7 @@ start_link() ->
 
 %% התחלת מנהל התור עם מספר שליחים מותאם
 start_link(NumCouriers) when is_integer(NumCouriers), NumCouriers > 0 ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [NumCouriers], []).
+    gen_server:start_link({via, global, ?MODULE}, ?MODULE, [NumCouriers], []).
 
 %% בקשת שליח פנוי מהתור (עם ציון האזור המבקש)
 request_courier(ZoneName) ->

--- a/src/location_tracker.erl
+++ b/src/location_tracker.erl
@@ -56,7 +56,7 @@
 %% -----------------------------------------------------------
 
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({via, global, ?MODULE}, ?MODULE, [], []).
 
 %% >> הערה חדשה: פונקציות API חדשות להשהיה והמשך <<
 pause() ->

--- a/src/logistics_sim_sup.erl
+++ b/src/logistics_sim_sup.erl
@@ -10,7 +10,7 @@
 
 %% התחלת הסופרווייזר
 start_link() ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+    supervisor:start_link({via, global, ?MODULE}, ?MODULE, []).
 
 %% אתחול הסופרווייזר והגדרת תהליכי התשתית
 init([]) ->
@@ -18,6 +18,14 @@ init([]) ->
     
     %% ChildSpecs – רשימת תהליכי התשתית כולל מודולי המפה
     ChildSpecs = [
+        %% Node Manager - monitors cluster nodes
+        #{id => node_manager,
+          start => {node_manager, start_link, []},
+          restart => permanent,
+          shutdown => 5000,
+          type => worker,
+          modules => [node_manager]},
+
         %% Map Server - חייב להיות ראשון כי אחרים תלויים בו
         #{id => map_server,
           start => {map_server, start_link, []},

--- a/src/logistics_state_collector.erl
+++ b/src/logistics_state_collector.erl
@@ -23,7 +23,7 @@
 %% -----------------------------------------------------------
 
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({via, global, ?MODULE}, ?MODULE, [], []).
 
 subscribe(HandlerPid) ->
     gen_server:cast(?MODULE, {subscribe, HandlerPid}).

--- a/src/logistics_web_server.erl
+++ b/src/logistics_web_server.erl
@@ -19,7 +19,7 @@
 
 %% התחלת שרת הווב
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({via, global, ?MODULE}, ?MODULE, [], []).
 
 %% עצירת שרת הווב
 stop() ->

--- a/src/map_server.erl
+++ b/src/map_server.erl
@@ -26,7 +26,7 @@
 %% -----------------------------------------------------------
 
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({via, global, ?MODULE}, ?MODULE, [], []).
 
 initialize_map(MapSize) ->
     gen_server:call(?MODULE, {initialize_map, MapSize}).

--- a/src/node_manager.erl
+++ b/src/node_manager.erl
@@ -1,0 +1,45 @@
+%% -----------------------------------------------------------
+%% Node Manager - monitors node connections
+%% Implements basic node monitoring using net_kernel:monitor_nodes/1
+%% -----------------------------------------------------------
+-module(node_manager).
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0, get_nodes/0]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+get_nodes() ->
+    gen_server:call(?MODULE, get_nodes).
+
+init([]) ->
+    net_kernel:monitor_nodes(true, [nodedown_reason]),
+    {ok, #{nodes => nodes()}}.
+
+handle_call(get_nodes, _From, State) ->
+    {reply, maps:get(nodes, State), State};
+handle_call(_Req, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({nodeup, Node}, State) ->
+    io:format("Node up: ~p~n", [Node]),
+    {noreply, State#{nodes => lists:usort([Node | maps:get(nodes, State)])}};
+handle_info({nodedown, Node, _Info}, State) ->
+    io:format("Node down: ~p~n", [Node]),
+    {noreply, State#{nodes => lists:delete(Node, maps:get(nodes, State))}};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/package.erl
+++ b/src/package.erl
@@ -15,7 +15,8 @@
 
 %% >> תיקון 2: שינוי בחתימת הפונקציה <<
 start_link(PkgId, Zone) ->
-    gen_statem:start_link({local, list_to_atom("package_" ++ PkgId)}, ?MODULE, [PkgId, Zone], []).
+    Name = list_to_atom("package_" ++ PkgId),
+    gen_statem:start_link({via, global, Name}, ?MODULE, [PkgId, Zone], []).
 
 callback_mode() -> handle_event_function.
 

--- a/src/random_order_generator.erl
+++ b/src/random_order_generator.erl
@@ -16,7 +16,7 @@
 %% start_link/0 - מתחיל תהליך מחולל רנדומלי יחיד
 %% -----------------------------------------------------------
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({via, global, ?MODULE}, ?MODULE, [], []).
 
 init([]) ->
     io:format("Random Order Generator started with fixed zones: ~p~n", [?FIXED_ZONES]),

--- a/src/simulation_supervisor.erl
+++ b/src/simulation_supervisor.erl
@@ -9,7 +9,7 @@
 
 %% התחלת הסופרווייזר
 start_link() ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+    supervisor:start_link({via, global, ?MODULE}, ?MODULE, []).
 
 %% אתחול הסופרווייזר
 init([]) ->

--- a/src/zone_manager.erl
+++ b/src/zone_manager.erl
@@ -17,7 +17,8 @@
 %% יצירת Zone Manager עבור אזור בשם zone_name (string)
 %% -----------------------------------------------------------
 start_link(ZoneName) ->
-    gen_statem:start_link({local, list_to_atom("zone_manager_" ++ ZoneName)}, ?MODULE, [ZoneName], []).
+    Name = list_to_atom("zone_manager_" ++ ZoneName),
+    gen_statem:start_link({via, global, Name}, ?MODULE, [ZoneName], []).
 
 %% תיקון: שינוי ל-handle_event mode
 callback_mode() -> handle_event_function.


### PR DESCRIPTION
## Summary
- add `node_manager` process for monitoring cluster nodes
- register major processes globally across nodes
- supervise the new `node_manager`

## Testing
- `rebar3 compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872ba7afcc48331abd2916e471efb13